### PR TITLE
Allow user to get the list of extra fields present in the entry.

### DIFF
--- a/src/_readtags.pyx
+++ b/src/_readtags.pyx
@@ -84,6 +84,10 @@ cdef class TagEntry:
 
             return result
 
+    def get_extra_fields(self):
+       return (self.c_entry.fields.list[i].key for i in range(self.c_entry.fields.count))
+
+
 cdef class CTags:
     cdef tagFile* file
     cdef tagFileInfo info


### PR DESCRIPTION
There are well known fields in the entry that are always available.
Other fields are also available but there is no way to know what they are
but trying to retrieve them.

The method get_extra_fields allow user code to get the list (iterator) of
extra fields present in the entry.
