### PR TITLE
Handle double backslashes at the end of pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 *NOTE*: This a fork from the original python-ctags that adds support for Python 3. It is currently maintained by Jonas Haag.
 
-Exuberant Ctags supports indexing of many modern programming languages.  Python is a powerful scriptable dynamic language.  Using Python to access Ctags index file is a natural fit in extending an application's capability to examine source code.
+Ctags supports indexing of many modern programming languages.  Python is a powerful scriptable dynamic language.  Using Python to access Ctags index file is a natural fit in extending an application's capability to examine source code.
 
 This project wrote a wrapper for read tags library.  I have been using the package in a couple of projects and it has been shown that it could easily handle hundreds of  source files.
 
 ## Requirements
  * C compiler (gcc/msvc)
  * Python version >= 2.6
- * [http://prdownloads.sourceforge.net/ctags/ctags-5.7.tar.gz Install Exuberant Ctags] (need it to generate tags file).
+ * Ctags implementation like [http://prdownloads.sourceforge.net/ctags/ctags-5.7.tar.gz Exuberant Ctags] or [https://github.com/universal-ctags/ctags Universal Ctags] (need it to generate tags file).
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
-"""Exuberant Ctags indexing python bindings
+"""Ctags indexing python bindings
 
-Exuberant Ctags supports indexing of many modern programming languages. Python
+Ctags supports indexing of many modern programming languages. Python
 is a powerful scriptable dynamic language. Using Python to access Ctags index
 file is a natural fit in extending an application's capability to examine source
 code.
 
-This project wrote a wrapper for readtags.c. I have been using the package in
+This project wrote a wrapper for readtags.c distributed from Universal-ctags project
+(https://ctags.io). I have been using the package in
 a couple of projects and it has been shown that it could easily handle hundreds
 source files.
 """

--- a/src/readtags.c
+++ b/src/readtags.c
@@ -1,6 +1,4 @@
 /*
-*   $Id$
-*
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released into the public domain.
@@ -60,7 +58,7 @@ struct sTagFile {
 			char *name;
 				/* length of name for partial matches */
 			size_t nameLength;
-				/* peforming partial match */
+				/* performing partial match */
 			short partial;
 				/* ignoring case */
 			short ignorecase;
@@ -88,8 +86,8 @@ struct sTagFile {
 /*
 *   DATA DEFINITIONS
 */
-const char *const EmptyString = "";
-const char *const PseudoTagPrefix = "!_";
+static const char *const EmptyString = "";
+static const char *const PseudoTagPrefix = "!_";
 
 /*
 *   FUNCTION DEFINITIONS
@@ -289,6 +287,26 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 	}
 }
 
+static int isOdd (unsigned int i)
+{
+	return  (i % 2);
+}
+
+static unsigned int countContinuousBackslashesBackward(const char *from,
+						     const char *till)
+{
+	unsigned int counter = 0;
+
+	for (; from > till; from--)
+	{
+		if (*from == '\\')
+			counter++;
+		else
+			break;
+	}
+	return counter;
+}
+
 static void parseTagLine (tagFile *file, tagEntry *const entry)
 {
 	int i;
@@ -321,7 +339,10 @@ static void parseTagLine (tagFile *file, tagEntry *const entry)
 				do
 				{
 					p = strchr (p + 1, delimiter);
-				} while (p != NULL  &&  *(p - 1) == '\\');
+				} while (p != NULL
+					 &&  isOdd (countContinuousBackslashesBackward (p - 1,
+											entry->address.pattern)));
+
 				if (p == NULL)
 				{
 					/* invalid pattern */
@@ -447,7 +468,7 @@ static tagFile *initialize (const char *const filePath, tagFileInfo *const info)
 		result->fields.max = 20;
 		result->fields.list = (tagExtensionField*) calloc (
 			result->fields.max, sizeof (tagExtensionField));
-		result->fp = fopen (filePath, "r");
+		result->fp = fopen (filePath, "rb");
 		if (result->fp == NULL)
 		{
 			free (result);
@@ -779,181 +800,5 @@ extern tagResult tagsClose (tagFile *const file)
 	}
 	return result;
 }
-
-/*
-*  TEST FRAMEWORK
-*/
-
-#ifdef READTAGS_MAIN
-
-static const char *TagFileName = "tags";
-static const char *ProgramName;
-static int extensionFields;
-static int SortOverride;
-static sortType SortMethod;
-
-static void printTag (const tagEntry *entry)
-{
-	int i;
-	int first = 1;
-	const char* separator = ";\"";
-	const char* const empty = "";
-/* "sep" returns a value only the first time it is evaluated */
-#define sep (first ? (first = 0, separator) : empty)
-	printf ("%s\t%s\t%s",
-		entry->name, entry->file, entry->address.pattern);
-	if (extensionFields)
-	{
-		if (entry->kind != NULL  &&  entry->kind [0] != '\0')
-			printf ("%s\tkind:%s", sep, entry->kind);
-		if (entry->fileScope)
-			printf ("%s\tfile:", sep);
-#if 0
-		if (entry->address.lineNumber > 0)
-			printf ("%s\tline:%lu", sep, entry->address.lineNumber);
-#endif
-		for (i = 0  ;  i < entry->fields.count  ;  ++i)
-			printf ("%s\t%s:%s", sep, entry->fields.list [i].key,
-				entry->fields.list [i].value);
-	}
-	putchar ('\n');
-#undef sep
-}
-
-static void findTag (const char *const name, const int options)
-{
-	tagFileInfo info;
-	tagEntry entry;
-	tagFile *const file = tagsOpen (TagFileName, &info);
-	if (file == NULL)
-	{
-		fprintf (stderr, "%s: cannot open tag file: %s: %s\n",
-				ProgramName, strerror (info.status.error_number), name);
-		exit (1);
-	}
-	else
-	{
-		if (SortOverride)
-			tagsSetSortType (file, SortMethod);
-		if (tagsFind (file, &entry, name, options) == TagSuccess)
-		{
-			do
-			{
-				printTag (&entry);
-			} while (tagsFindNext (file, &entry) == TagSuccess);
-		}
-		tagsClose (file);
-	}
-}
-
-static void listTags (void)
-{
-	tagFileInfo info;
-	tagEntry entry;
-	tagFile *const file = tagsOpen (TagFileName, &info);
-	if (file == NULL)
-	{
-		fprintf (stderr, "%s: cannot open tag file: %s: %s\n",
-				ProgramName, strerror (info.status.error_number), TagFileName);
-		exit (1);
-	}
-	else
-	{
-		while (tagsNext (file, &entry) == TagSuccess)
-			printTag (&entry);
-		tagsClose (file);
-	}
-}
-
-const char *const Usage =
-	"Find tag file entries matching specified names.\n\n"
-	"Usage: %s [-ilp] [-s[0|1]] [-t file] [name(s)]\n\n"
-	"Options:\n"
-	"    -e           Include extension fields in output.\n"
-	"    -i           Perform case-insensitive matching.\n"
-	"    -l           List all tags.\n"
-	"    -p           Perform partial matching.\n"
-	"    -s[0|1|2]    Override sort detection of tag file.\n"
-	"    -t file      Use specified tag file (default: \"tags\").\n"
-	"Note that options are acted upon as encountered, so order is significant.\n";
-
-extern int main (int argc, char **argv)
-{
-	int options = 0;
-	int actionSupplied = 0;
-	int i;
-	ProgramName = argv [0];
-	if (argc == 1)
-	{
-		fprintf (stderr, Usage, ProgramName);
-		exit (1);
-	}
-	for (i = 1  ;  i < argc  ;  ++i)
-	{
-		const char *const arg = argv [i];
-		if (arg [0] != '-')
-		{
-			findTag (arg, options);
-			actionSupplied = 1;
-		}
-		else
-		{
-			size_t j;
-			for (j = 1  ;  arg [j] != '\0'  ;  ++j)
-			{
-				switch (arg [j])
-				{
-					case 'e': extensionFields = 1;         break;
-					case 'i': options |= TAG_IGNORECASE;   break;
-					case 'p': options |= TAG_PARTIALMATCH; break;
-					case 'l': listTags (); actionSupplied = 1; break;
-			
-					case 't':
-						if (arg [j+1] != '\0')
-						{
-							TagFileName = arg + j + 1;
-							j += strlen (TagFileName);
-						}
-						else if (i + 1 < argc)
-							TagFileName = argv [++i];
-						else
-						{
-							fprintf (stderr, Usage, ProgramName);
-							exit (1);
-						}
-						break;
-					case 's':
-						SortOverride = 1;
-						++j;
-						if (arg [j] == '\0')
-							SortMethod = TAG_SORTED;
-						else if (strchr ("012", arg[j]) != NULL)
-							SortMethod = (sortType) (arg[j] - '0');
-						else
-						{
-							fprintf (stderr, Usage, ProgramName);
-							exit (1);
-						}
-						break;
-					default:
-						fprintf (stderr, "%s: unknown option: %c\n",
-									ProgramName, arg[j]);
-						exit (1);
-						break;
-				}
-			}
-		}
-	}
-	if (! actionSupplied)
-	{
-		fprintf (stderr,
-			"%s: no action specified: specify tag name(s) or -l option\n",
-			ProgramName);
-		exit (1);
-	}
-	return 0;
-}
-
-#endif
 
 /* vi:set tabstop=4 shiftwidth=4: */


### PR DESCRIPTION
Close #7.
For fixing the bug, readtags.c is replaced with that of universal-ctags(https://ctags.io).
