### PR TITLE
Python 3.6 disagrees on ctagsOpen(<str>) and asks for a bytes() variable

### DIFF
--- a/src/_readtags.pyx
+++ b/src/_readtags.pyx
@@ -89,7 +89,7 @@ cdef class CTags:
     cdef tagFileInfo info
 
     def __cinit__(self, filepath):
-        self.open(filepath.encode())
+        self.open(filepath)
 
     def __dealloc__(self):
 
@@ -124,7 +124,11 @@ cdef class CTags:
 
 
     def open(self, filepath):
-        self.file = ctagsOpen(filepath, &self.info)
+        if type(filepath) is str:
+            self.file = ctagsOpen(filepath.encode(), &self.info)
+        else:
+            self.file = ctagsOpen(filepath, &self.info)
+            
 
         if not self.info.status.opened:
             raise Exception('Invalid tag file')

--- a/src/_readtags.pyx
+++ b/src/_readtags.pyx
@@ -89,7 +89,7 @@ cdef class CTags:
     cdef tagFileInfo info
 
     def __cinit__(self, filepath):
-        self.open(filepath)
+        self.open(filepath.encode())
 
     def __dealloc__(self):
 


### PR DESCRIPTION
I'm just beginning the use of this version of the library and it prompted an error upon opening the tags file.... I tried convincing cython3 that this is a string argument, but it doesn't seem to agree with me and it's likely easier to just convert strings to bytes().